### PR TITLE
Allow user to provide a template to render a custom .modal-dialog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,3 +2,8 @@
   - Initial release.
 * Version 0.0.2: 19.02.2015
   - Added option to render a SimpleSchema as an AutoForm and receive the form data in the callback.
+* Version 0.0.3: 19.02.2015
+  - Added option to render a custom modal-dialog template
+  - Added ability to close modal programatically
+  - Wrapped API in closure
+  - Added ability to hide cancel and confirm buttons by setting text to null

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You can manually include it in your project, or use one of the many Bootstrap pa
 
 ## Usage
 
+### Prompt
+
 * Show a simple dialog with text content:
 
 ```javascript
@@ -81,6 +83,56 @@ BootstrapModalPrompt.prompt({
 Hint: if you want to customize the form with {{#autoForm}} or do other javascript stuff,
 use a custom template as shown above!
 
+* Render a custom modal-dialog template for ultimate flexibility
+
+```html
+<template name="RequestDemoModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h3 class="modal-title" id="myModalLabel">We want to hear you out!</h3>
+      </div>
+      {{#autoForm id='requestDemo' schema=requestDemoSchema type="method" meteormethod="requestDemo" resetOnSuccess=false}}
+      <div class="modal-body">
+        <p>Provide us some info to get in touch.</p>
+        {{> afQuickField name="name"}}
+        {{> afQuickField name="email"}}
+        {{> afQuickField name="phone"}}
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary btn-block">Send</button>
+      </div>
+      {{/autoForm}}
+    </div>
+  </div>
+</template>
+```
+
+```javascript
+Template.site.events({
+  'click .js-request-demo': function () {
+    BootstrapModalPrompt.prompt({
+      dialogTemplate: Template.RequestDemoModal
+    });
+  }
+});
+
+Template.RequestDemoModal.helpers({
+  requestDemoSchema: function () {
+    return Schema.RequestDemo;
+  }
+});
+
+AutoForm.hooks({
+  requestDemo: {
+    onSuccess: function(operation, result, template) {
+      BootstrapModalPrompt.dismiss();
+    }
+  }
+});
+```
+
 ## API & Options
 
 BootstrapModalPrompt.prompt(options, callback);
@@ -91,10 +143,11 @@ Option | Description
 ------ | -----------
 title | The modal title
 content | A string that will be used as the modal body content
-template | A Meteor Template instance that should be renderd as the body content (supersedes "content")
+template | A Meteor Template instance that should be rendered as the body content (supersedes "content")
 templateData | an object with data that will be available to the custom template
-btnDismissText | Text of the dismiss button
-btnOkText | Text of the confirm button
+dialogTemplate | A Meteor Template instance that should be rendered as the modal dialog (supersedes 'content' and 'template') (works with templateData)
+btnDismissText | Text of the dismiss button - set to null to hide
+btnOkText | Text of the confirm button - set to null to hide
 beforeShow | Callback that will be called before the modal is displayed. Receives the options and the modal DOM node as arguments
 afterShow | Callback that will be called once the modal is displayed and all transitions are complete. Receives the options and the modal DOM node as arguments
 beforeHide | Callback that will be called before the modal is hidden. Receives the options and the modal DOM node as arguments

--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ AutoForm.hooks({
 });
 ```
 
+### Dismiss
+
+* Dismiss the current modal
+
+```javascript
+BootstrapModalPrompt.dismiss();
+```
+
 ## API & Options
 
 BootstrapModalPrompt.prompt(options, callback);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This [Atmosphere package](https://atmospherejs.com/theduke/bootstrap-modal-prompt) for [Meteor](http://meteor.com) makes it really easy to show a confirm dialog with custom content to the user, and get the result. You can also use a custom template for the content, and even specify a SimpleSchema to generate a form with AutoForm and get the form data in a callback.
 
-Version: 0.0.2
+Version: 0.0.3
 
 ## Installation
 

--- a/package.js
+++ b/package.js
@@ -1,13 +1,11 @@
 Package.describe({
   name: 'theduke:bootstrap-modal-prompt',
   summary: "Show prompts in a bootstrap modal.",
-  version: "0.0.2",
+  version: "0.0.3",
   git: "https://github.com/theduke/meteor-bootstrap-modal-prompt"
 });
 
 Package.onUse(function (api) {
-  var both = ['client', 'server'];
-
   api.versionsFrom('METEOR@1.0');
 
   api.use('underscore', 'client');
@@ -15,21 +13,8 @@ Package.onUse(function (api) {
 
   api.export('BootstrapModalPrompt', 'client');
 
-  // Common client and server files.
-  api.addFiles([
-   
-  ], both);
-
-  // Server only files.
-  api.addFiles([
-  ], 'server'); 
-
-  // Templates.
   api.addFiles([
     'prompt.js'
   ], 'client');
 
-  // Client only files.
-  api.addFiles([
-  ], 'client');
 });

--- a/prompt.js
+++ b/prompt.js
@@ -1,5 +1,3 @@
-console.log('loading from packages dir');
-
 BootstrapModalPrompt = function() {
   var exports = {};
   /*

--- a/prompt.js
+++ b/prompt.js
@@ -153,6 +153,11 @@ BootstrapModalPrompt = function() {
       modal.find('.modal-btn-dismiss').remove();
     }
 
+    // if btnOkText is falsey, remove it
+    if (!options.btnOkText) {
+      modal.find('.modal-btn-save').remove();
+    }
+
     modal.on('shown.bs.modal', function() {
       if (options.afterShow) {
         options.afterShow(options, modal.get(0));

--- a/prompt.js
+++ b/prompt.js
@@ -206,7 +206,7 @@ BootstrapModalPrompt = function() {
   };
 
   // Dismisses current modal if open
-  exports.dismiss = function(callback) {
+  exports.dismiss = function() {
     var modal = $('.modal', '.bs-prompt-modal');
     modal.modal('hide');
   }

--- a/prompt.js
+++ b/prompt.js
@@ -1,7 +1,7 @@
 console.log('loading from packages dir');
 
-BootstrapModalPrompt = {
-
+BootstrapModalPrompt = function() {
+  var exports = {};
   /*
    * Expected format of options:
    * {
@@ -14,7 +14,7 @@ BootstrapModalPrompt = {
    *   onShown: function() {} // callback function.
    * }
    */
-  prompt: function(options, callback) {
+  exports.prompt = function(options, callback) {
     options = _.extend({
       title: 'Confirmation',
       content: '',
@@ -62,7 +62,7 @@ BootstrapModalPrompt = {
 
     var modalWrap = $('.bs-prompt-modal');
     if (!modalWrap.size()) {
-      modalWrap = this.createModal();
+      modalWrap = createModal();
     }
 
     var modal = modalWrap.find('.modal');
@@ -77,7 +77,7 @@ BootstrapModalPrompt = {
     } else {
       // need to create a dialog if one isn't provided
       if (!dialog.size()) {
-        dialog = this.createModalDialog(modal);  
+        dialog = createModalDialog(modal);  
       }
       
       dialog.find('.modal-title').html(options.title);
@@ -200,17 +200,24 @@ BootstrapModalPrompt = {
     });
 
     modal.modal('show');
-  },
+  };
 
-  createModal: function() {
+  // Dismisses current modal if open
+  exports.dismiss = function(callback) {
+    var modal = $('.modal', '.bs-prompt-modal');
+    modal.modal('hide');
+  }
+
+  var createModal = function() {
     var tpl = '<div class="bs-prompt-modal">' +
                 '<div class="modal fade"></div>' +
               '</div>';
 
     $('body').append(tpl);
     return $('.bs-prompt-modal');
-  },
-  createModalDialog: function($modal) {
+  };
+
+  var createModalDialog = function($modal) {
     var tpl = '<div class="modal-dialog"><div class="modal-content">' +
                   '<div class="modal-header">' +
                     '<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
@@ -226,5 +233,7 @@ BootstrapModalPrompt = {
                 '</div></div>';
     $modal.append(tpl);
     return $('.modal-dialog');          
-  }
-};
+  };
+
+  return exports;
+}();

--- a/prompt.js
+++ b/prompt.js
@@ -69,8 +69,13 @@ BootstrapModalPrompt = {
     var dialog = $('.modal-dialog', modalWrap); 
     var body;
 
-    if (!options.dialogTemplate) {
-
+    if (options.dialogTemplate) {
+      // reset the dialog if it exists as custom template will render it
+      if (dialog.size()) {
+        dialog.remove();
+      }
+    } else {
+      // need to create a dialog if one isn't provided
       if (!dialog.size()) {
         dialog = this.createModalDialog(modal);  
       }
@@ -97,7 +102,8 @@ BootstrapModalPrompt = {
       }
 
       modal.modal('hide');
-      callback(data ? data : true);
+      if (callback)
+        callback(data ? data : true);
     }
 
     var content = options.content;
@@ -174,7 +180,8 @@ BootstrapModalPrompt = {
       }
 
       modal.modal('hide');
-      callback(false);
+      if (callback)
+        callback(false);
 
       return false;
     });


### PR DESCRIPTION
I had a use for this in my application, and was making a package to do something similar when I saw your package on meteor-talk.

I decided it'd be better to combine our efforts.

This allows users to specify an entirely custom .modal-dialog, rather than having to work within the constraints of the body only. This is great for complex dialogs with custom logic. I also wrapped the lib in a closure, and only exported functions to be used by the api user. Lastly, I added BootstrapModalPrompt.dismiss() to dismiss the current modal.

I used it for a "Request Demo" form. I wanted the button for the form to be rendered in the modal-footer so it would match the bootstrap styles.

``` html
<template name="RequestDemoModal">
  <div class="modal-dialog">
    <div class="modal-content">
      <div class="modal-header">
        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
        <h3 class="modal-title" id="myModalLabel">We want to hear you out!</h3>
      </div>
      {{#autoForm id='requestDemo' schema=requestDemoSchema type="method" meteormethod="requestDemo" resetOnSuccess=false}}
      <div class="modal-body">
        <p>Provide us some info to get in touch.</p>
        {{> afQuickField name="name"}}
        {{> afQuickField name="email"}}
        {{> afQuickField name="phone"}}
      </div>
      <div class="modal-footer">
        <button type="submit" class="btn btn-primary btn-block">Send</button>
      </div>
      {{/autoForm}}
    </div>
  </div>
</template>
```

``` javascript
Template.site.events({
  'click .js-request-demo': function () {
    BootstrapModalPrompt.prompt({
      dialogTemplate: Template.RequestDemoModal
    });
  }
});

Template.RequestDemoModal.helpers({
  requestDemoSchema: function () {
    return Schema.RequestDemo;
  }
});

AutoForm.hooks({
  requestDemo: {
    onSuccess: function(operation, result, template) {
      BootstrapModalPrompt.dismiss();
    }
  }
});
```
